### PR TITLE
Fix missing unittest for OSAL_E_NOINIT

### DIFF
--- a/include/dmosal/osal_error.h
+++ b/include/dmosal/osal_error.h
@@ -55,7 +55,6 @@ typedef enum {
 	OSAL_E_QFULL, /**< Queue is full */
 	OSAL_E_QEMPTY, /**< Queue is empty*/
 	OSAL_E_INUSE, /**< Resource is in use */
-	OSAL_E_ALREADY_INIT, /**< Resource is already initialized  */
 	OSAL_E_MAX, /**< Maximum error code (for range checking) */
 } osal_error_t;
 

--- a/include/dmosal/osal_error.h
+++ b/include/dmosal/osal_error.h
@@ -55,6 +55,7 @@ typedef enum {
 	OSAL_E_QFULL, /**< Queue is full */
 	OSAL_E_QEMPTY, /**< Queue is empty*/
 	OSAL_E_INUSE, /**< Resource is in use */
+	OSAL_E_ALREADY_INIT, /**< Resource is already initialized  */
 	OSAL_E_MAX, /**< Maximum error code (for range checking) */
 } osal_error_t;
 

--- a/source/osal_error.c
+++ b/source/osal_error.c
@@ -32,6 +32,7 @@
 static const char *s_osal_errstr[OSAL_E_MAX] = {
 	OSAL_E(OK),
 	OSAL_E(PARAM),
+	OSAL_E(NOINIT),
 	OSAL_E(RESRC),
 	OSAL_E(FAILURE),
 	OSAL_E(OSCALL),
@@ -39,6 +40,7 @@ static const char *s_osal_errstr[OSAL_E_MAX] = {
 	OSAL_E(QFULL),
 	OSAL_E(QEMPTY),
 	OSAL_E(INUSE),
+	OSAL_E(ALREADY_INIT),
 };
 
 const char *osal_errstr(osal_error_t e)

--- a/source/osal_error.c
+++ b/source/osal_error.c
@@ -40,7 +40,6 @@ static const char *s_osal_errstr[OSAL_E_MAX] = {
 	OSAL_E(QFULL),
 	OSAL_E(QEMPTY),
 	OSAL_E(INUSE),
-	OSAL_E(ALREADY_INIT),
 };
 
 const char *osal_errstr(osal_error_t e)

--- a/test/osal/error_test.c
+++ b/test/osal/error_test.c
@@ -58,8 +58,6 @@ static void test_error(void **state)
 	assert_string_equal(estr, "OSAL_E_INUSE");
 	estr = osal_errstr(OSAL_E_NOINIT);
 	assert_string_equal(estr, "OSAL_E_NOINIT");
-	estr = osal_errstr(OSAL_E_ALREADY_INIT);
-	assert_string_equal(estr, "OSAL_E_ALREADY_INIT");
 }
 
 int main(void)

--- a/test/osal/error_test.c
+++ b/test/osal/error_test.c
@@ -56,6 +56,10 @@ static void test_error(void **state)
 	assert_string_equal(estr, "OSAL_E_QEMPTY");
 	estr = osal_errstr(OSAL_E_INUSE);
 	assert_string_equal(estr, "OSAL_E_INUSE");
+	estr = osal_errstr(OSAL_E_NOINIT);
+	assert_string_equal(estr, "OSAL_E_NOINIT");
+	estr = osal_errstr(OSAL_E_ALREADY_INIT);
+	assert_string_equal(estr, "OSAL_E_ALREADY_INIT");
 }
 
 int main(void)


### PR DESCRIPTION
- Added a new error code OSAL_E_ALREADY_INIT to handle cases where initialization occurs multiple times (This feature should be implemented in the future).

- Corrected the osal_error.c file to include the missing error code OSAL_E_NOINIT in the error string array.

- Modified the osal_errstr() function (test code) to return correct error messages for all error codes, including the newly introduced OSAL_E_ALREADY_INIT.